### PR TITLE
Add width to pointer directly.

### DIFF
--- a/css/colorjoe.css
+++ b/css/colorjoe.css
@@ -72,6 +72,7 @@
 .colorPicker .twod .pointer {
     position: relative;
     z-index: 2;
+    width: 8px;
 }
 .colorPicker .twod .pointer .shape {
     position: absolute;


### PR DESCRIPTION
Can cause unwanted overflows in some situations without it
