### PR TITLE
Callback "done" does not get triggered when using rgb

### DIFF
--- a/src/colorjoe.js
+++ b/src/colorjoe.js
@@ -146,7 +146,7 @@ function setup(o) {
     // Do not call done callback if the color did not change
     if (previous.equals(col)) return;
     for(var i = 0, len = listeners.done.length; i < len; i++) {
-      listeners.done[i](col);
+      listeners.done[i].fn(col);
     }
     previous = col;
   }


### PR DESCRIPTION
I was doing something like this:

```
@colorPicker = colorjoe.rgb "color-picker", [....], [...]

@colorPicker.on "done", (color) ->
  ...
```

But then I realized that this does not work and throws an error. I dug a bit in the source code and noticed that it needed a minor fix. Not sure if this works in all cases, so I'll let you be the judge of that. Hope this helps.
