### PR TITLE
Fix removing all listeners

### DIFF
--- a/src/colorjoe.js
+++ b/src/colorjoe.js
@@ -221,10 +221,10 @@ function setup(o) {
         },
         removeAllListeners: function(evt) {
             if (evt) {
-                delete listeners[evt];
+                listeners[evt] = [];
             } else {
                 for (var key in listeners) {
-                    delete listeners[key];
+                    listeners[key] = [];
                 }
             }
 


### PR DESCRIPTION
This change fixes scenario:
1. Setup colorjoe
2. Add some listeners
3. Call removeAllListeners
4. Add other listeners - colorjoe will crash with error:
`Uncaught TypeError: Cannot read property 'push' of undefined`